### PR TITLE
added event trigger for quickfix (default on)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can disable this feature with this configuration:
 require("bacon").setup({
     quickfix  = {
          enabled = false -- true to populate the quickfix list with bacon errors and warnings
+         event = true -- triggers the QuickFixCmdPost event after populating the quickfix list
     }
 )}
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can disable this feature with this configuration:
 require("bacon").setup({
     quickfix  = {
          enabled = false -- true to populate the quickfix list with bacon errors and warnings
-         event = true -- triggers the QuickFixCmdPost event after populating the quickfix list
+         event_trigger = true -- triggers the QuickFixCmdPost event after populating the quickfix list
     }
 )}
 ```

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ To navigate among errors and warnings, you'll use either the standard Quickfix f
 
 The following functions are exposed by the plugin:
 
-|Function|Usage|
-|-|-|
-|`:BaconLoad`| Silently load the locations of the `.bacon-locations` file|
-|`:BaconShow`| Display the locations in a floating windoaw|
-|`:BaconList`| Does `:BaconLoad` then `:BaconShow`|
-|`:BaconPrevious`| Jump to the previous location in the current list |
-|`:BaconNext`| Jump to the next location in the current list |
-
+| Function         | Usage                                                      |
+| ---------------- | ---------------------------------------------------------- |
+| `:BaconLoad`     | Silently load the locations of the `.bacon-locations` file |
+| `:BaconShow`     | Display the locations in a floating windoaw                |
+| `:BaconList`     | Does `:BaconLoad` then `:BaconShow`                        |
+| `:BaconPrevious` | Jump to the previous location in the current list          |
+| `:BaconNext`     | Jump to the next location in the current list              |
 
 You should define at least two shortcuts, for example like this:
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ The first shortcut navigates from location to location, without opening the wind
 This is probably the one you'll use all the time.
 You may notice it loads the list (`:BaconLoad`) then saves the current document (`:w`), to prevent both race conditions and having a bunch of unsaved buffers.
 
-The second shorctut, which is mapped to the <kbd>,</kbd> key, opens the list of all bacon locations:
+The second shortcut, which is mapped to the <kbd>,</kbd> key, opens the list of all bacon locations:
 
 ![list](doc/list.png)
 
-When the list is open, you can select a line and hit <kbd>enter</kbd> or just hit the numero of the location if it's in 1-9.
+When the list is open, you can select a line and hit <kbd>enter</kbd> or just hit the number of the location if it's in 1-9.
 As there's no need to wait for the window to appear, you may just type <kbd>,</kbd><kbd>3</kbd> to go to location 3 without opening the window.
 
 You may define other shortcuts using the various API functions.

--- a/lua/bacon/config.lua
+++ b/lua/bacon/config.lua
@@ -3,6 +3,7 @@ local M = {}
 local defaults = {
 	quickfix = {
 		enabled = true,
+		event = true,
 	},
 }
 

--- a/lua/bacon/config.lua
+++ b/lua/bacon/config.lua
@@ -3,7 +3,7 @@ local M = {}
 local defaults = {
 	quickfix = {
 		enabled = true,
-		event = true,
+		event_trigger = true,
 	},
 }
 

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -174,7 +174,7 @@ function Bacon.bacon_load()
 				vim.fn.setqflist(locations, " ")
 				vim.fn.setqflist({}, "a", { title = "Bacon" })
 
-				if config.options.quickfix.event then
+				if config.options.quickfix.event_trigger then
 					vim.cmd("doautocmd QuickFixCmdPost")
 				end
 			end

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -173,6 +173,10 @@ function Bacon.bacon_load()
 			if config.options.quickfix.enabled then
 				vim.fn.setqflist(locations, " ")
 				vim.fn.setqflist({}, "a", { title = "Bacon" })
+
+				if config.options.quickfix.event then
+					vim.cmd("doautocmd QuickFixCmdPost")
+				end
 			end
 			location_idx = 0
 			if old_location then
@@ -192,13 +196,13 @@ end
 -- Fill our buf with the locations, one per line
 local function update_view()
 	vim.api.nvim_buf_set_option(buf, "modifiable", true)
-	local cwd = vim.fn.getcwd() .. '/'
+	local cwd = vim.fn.getcwd() .. "/"
 	local lines = {}
 	for i, location in ipairs(locations) do
 		local cat = string.upper(location.text):sub(1, 1)
 		local path = location.filename
 		if string.find(path, cwd) == 1 then
-			path = string.gsub(location.filename, cwd, '')
+			path = string.gsub(location.filename, cwd, "")
 		end
 		local shield = center("" .. i, 5)
 		table.insert(lines, " " .. cat .. shield .. path .. ":" .. location.lnum .. ":" .. location.col)

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -175,6 +175,7 @@ function Bacon.bacon_load()
 				vim.fn.setqflist({}, "a", { title = "Bacon" })
 
 				if config.options.quickfix.event_trigger then
+					-- triggers the Neovim event for populating the quickfix list
 					vim.cmd("doautocmd QuickFixCmdPost")
 				end
 			end


### PR DESCRIPTION
Added the QuickFixCmdPost event trigger when the quickfix list gets populated. This event normally fires after running native quickfix commands like  `:grep` or `:make`, so this change just makes it play nicely for any autocommands using that event. I added a configuration option that defaulted as enabled, because while this is fairly intuitive functionality, some users may not wish to have the event triggered.

(The change to the quotation marks was just my autoformatter, can change it if you have strong feelings on it) 