### PR TITLE
Auto load on save.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export_locations = true
 
 You'll use this plugin in nvim while a bacon instance is running in another panel, probably side to it.
 
-To navigate among errors and warnings, you'll use either the standard Quickfix feature of your editor or nvim-bacon dedicated commands and view.
+To navigate errors and warnings, you can either use the standard [Quickfix](http://neovim.io/doc/user/quickfix.html) feature of your editor or `nvim-bacon`'s dedicated commands and view.
 
 ### Specialized Commands and View
 
@@ -54,17 +54,16 @@ As there's no need to wait for the window to appear, you may just type <kbd>,</k
 
 You may define other shortcuts using the various API functions.
 
-### Quickfix Integration
+### Configuration
 
-Errors and warnings also populate the [Quicklist](http://neovim.io/doc/user/quickfix.html) list by default.
-
-You can disable this feature with this configuration:
+The default configuration options can be found below.
 
 ```lua
 require("bacon").setup({
     quickfix  = {
-         enabled = false -- true to populate the quickfix list with bacon errors and warnings
+         enabled = true -- populates the quickfix list with bacon errors and warnings
          event_trigger = true -- triggers the QuickFixCmdPost event after populating the quickfix list
-    }
+    },
+    autoload = true -- Automatically loads locations on save.
 )}
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The default configuration options can be found below.
 ```lua
 require("bacon").setup({
     quickfix  = {
-         enabled = true -- populates the quickfix list with bacon errors and warnings
+         enabled = true, -- populates the quickfix list with bacon errors and warnings
          event_trigger = true -- triggers the QuickFixCmdPost event after populating the quickfix list
     },
     autoload = true -- Automatically loads locations on save.

--- a/lua/bacon/config.lua
+++ b/lua/bacon/config.lua
@@ -5,6 +5,7 @@ local defaults = {
 		enabled = true,
 		event_trigger = true,
 	},
+	autoload = true,
 }
 
 M.options = {}

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -268,5 +268,11 @@ function Bacon.bacon_next()
 	end
 end
 
+if config.options.autoload then
+	vim.api.nvim_create_autocmd("FileType", {
+		pattern = { "rust" },
+		callback = function() end,
+	})
+end
 -- Return the public API
 return Bacon

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -174,7 +174,7 @@ function Bacon.bacon_load()
 					}
 					if text ~= "" then
 						location.text = text
-					else 
+					else
 						location.text = ""
 					end
 					table.insert(locations, location)

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -300,10 +300,10 @@ local function watch_loc_file(path)
 				Bacon.bacon_load()
 			end)
 		end
-		loop.fs_event_stop(handle)
 	end
-
 	loop.fs_event_start(handle, path, flags, event_cb)
+
+	return handle
 end
 
 if config.options.autoload then
@@ -311,9 +311,10 @@ if config.options.autoload then
 		pattern = { "rust" },
 		callback = function()
 			local path = find_loc_file()
-			api.nvim_create_autocmd("BufWritePost", {
+			local handle = watch_loc_file(path) -- creates watcher when opening/creating rust file
+			api.nvim_create_autocmd("QuitPre", {
 				callback = function()
-					watch_loc_file(path)
+					loop.fs_event_stop(handle) -- closes watcher on exit
 				end,
 			})
 		end,

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -296,7 +296,9 @@ local function watch_loc_file(path)
 		if err then
 			error("Autoload failed to watch .bacon-locations")
 		else
-			Bacon.bacon_load()
+			vim.schedule(function()
+				Bacon.bacon_load()
+			end)
 		end
 		loop.fs_event_stop(handle)
 	end

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -292,7 +292,7 @@ local function watch_loc_file(path)
 		recursive = false,
 	}
 
-	local event_cb = function(err, filename, events)
+	local event_cb = function(err, _, _)
 		if err then
 			error("Autoload failed to watch .bacon-locations")
 		else
@@ -311,12 +311,14 @@ if config.options.autoload then
 		pattern = { "rust" },
 		callback = function()
 			local path = find_loc_file()
-			local handle = watch_loc_file(path) -- creates watcher when opening/creating rust file
-			api.nvim_create_autocmd("QuitPre", {
-				callback = function()
-					loop.fs_event_stop(handle) -- closes watcher on exit
-				end,
-			})
+			if path then
+				local handle = watch_loc_file(path) -- creates watcher when opening/creating rust file
+				api.nvim_create_autocmd("QuitPre", {
+					callback = function()
+						loop.fs_event_stop(handle) -- closes watcher on exit
+					end,
+				})
+			end
 		end,
 	})
 end

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -268,6 +268,17 @@ function Bacon.bacon_next()
 	end
 end
 
+local function find_loc_file()
+	local dir = ""
+	repeat
+		local file = dir .. ".bacon-locations"
+		if file_exists(file) then
+			return file
+		end
+		dir = "../" .. dir
+	until not file_exists(dir)
+end
+
 if config.options.autoload then
 	vim.api.nvim_create_autocmd("FileType", {
 		pattern = { "rust" },


### PR DESCRIPTION
Provides in-built functionality for #8.

Based on the source code for [fwatch.nvim](https://github.com/rktjmp/fwatch.nvim), this change creates an autocommand when the plugin is loaded which creates a watcher whenever a Rust file is saved. When the watcher detects a change to the file, it will run the bacon_load function, loading the new locations into the plugin's storage. The watcher is then stopped.

This implementation has the same requirements as `fwatch.nvim`.

If you'd prefer the functionality to not be in-built, I could instead make a section for the README on how a user can add the functionality to their config.
