### PR TITLE
fix error on closing double opened bacon list

### DIFF
--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -21,6 +21,8 @@ local function center(str, width)
 end
 
 local function open_window()
+	Bacon.close_window() -- close the window if it's already open
+
 	buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
 	vim.api.nvim_buf_set_option(buf, "filetype", "bacon")
@@ -49,8 +51,14 @@ local function open_window()
 	api.nvim_buf_add_highlight(buf, -1, "BaconHeader", 0, 0, -1)
 end
 
+-- Close the bacon list. Do nothing if it's not open
 function Bacon.close_window()
-	api.nvim_win_close(win, true)
+	if win ~= nil then
+		if win == api.nvim_get_current_win() then
+			api.nvim_win_close(win, true)
+		end
+		win = nil
+	end
 end
 
 -- Tell whether a file exists


### PR DESCRIPTION
1. close the previous window, if any, on opening the list
2. check the window is (still) open before trying to close it

Fix #10 