### PR TITLE
Minor readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Plug 'Canop/nvim-bacon'
 You must [enable locations export in bacon](https://dystroy.org/bacon/config/#export-locations). Add this to your bacon.prefs file:
 
 ```toml
-export_locations = true
+[export]
+enabled = true
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plug 'Canop/nvim-bacon'
 
 You must [enable locations export in bacon](https://dystroy.org/bacon/config/#export-locations). Add this to your bacon.prefs file:
 
-```TOML
+```toml
 export_locations = true
 ```
 


### PR DESCRIPTION
Hi again, sorry for spamming 😄 just starting to figure this plugin out, I really love the idea!

# docs: fix strange incompatibility with treesitter highlighting

When opening the readme in neovim 0.10.0, I got this error:

```
   Error  Error in decoration provider treesitter/highlighter.win:
Error executing lua: /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:252: no such language: TOML
stack traceback:
```

Not sure why this is happening, but I'm guessing it's because of a bug
in the treesitter highlighting. It seems to be possible to work around
this by lowercasing the language name in the code block.

# docs: update export_locations setting syntax to the current version

Looks like the readme suggested a deprecated version of this setting.

It seems to have been deprecated about a year ago in this commit:
https://github.com/Canop/bacon/commit/7bf319d4772fd189260e35b2867e3d8199f84dbb