### PR TITLE
fix: endless loop when locations file is not found

### DIFF
--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -62,7 +62,7 @@ function Bacon.close_window()
 end
 
 -- Tell whether a file exists
-function file_exists(file)
+local function file_exists(file)
 	local f = io.open(file, "rb")
 	if f then
 		f:close()
@@ -71,7 +71,7 @@ function file_exists(file)
 end
 
 -- get all lines from a file
-function lines_from(file)
+local function lines_from(file)
 	local lines = {}
 	for line in io.lines(file) do
 		lines[#lines + 1] = line
@@ -169,17 +169,17 @@ function Bacon.bacon_load()
 				-- each line is like "error lua/bacon.lua:61:15 the faucet is leaking"
 				-- print('parse raw "' .. raw_line .. '"')
 				local cat
-                		local path
-                		local line
-                		local col
-                		local text
+				local path
+				local line
+				local col
+				local text
 
 				if vim.fn.has("win32") then
-		                    raw_line = raw_line:gsub("\\", "/")
-		                    cat, path, line, col, text = string.match(raw_line, "(%S+) (%a:[^:]+):(%d+):(%d+)%s*(.*)")
-		                else
-		                    cat, path, line, col, text = string.match(raw_line, "(%S+) ([^:]+):(%d+):(%d+)%s*(.*)")
-		                end
+					raw_line = raw_line:gsub("\\", "/")
+					cat, path, line, col, text = string.match(raw_line, "(%S+) (%a:[^:]+):(%d+):(%d+)%s*(.*)")
+				else
+					cat, path, line, col, text = string.match(raw_line, "(%S+) ([^:]+):(%d+):(%d+)%s*(.*)")
+				end
 
 				if cat ~= nil and #cat > 0 then
 					local loc_path = path
@@ -194,7 +194,7 @@ function Bacon.bacon_load()
 					}
 					if text ~= "" then
 						location.text = text
-					else 
+					else
 						location.text = ""
 					end
 					table.insert(locations, location)

--- a/lua/bacon/init.lua
+++ b/lua/bacon/init.lua
@@ -219,6 +219,10 @@ function Bacon.bacon_load()
 			end
 			break
 		end
+
+		if vim.loop.fs_realpath(dir) == "/" then
+			break
+		end
 		dir = "../" .. dir
 	until not file_exists(dir)
 end


### PR DESCRIPTION
If the .bacon-locations file is missing, the `Bacon.bacon_load()` function goes into an endless loop, forever trying to recurse up path the root directory (`/` -> `/../` -> `/../../` -> ...).

If I add a `vim.notify` call to the `Bacon.bacon_load()` function, it shows notifications for `path`, `path/../` and `path/../../` but never finishes.

```
   Info  11:33:29 notify.info found file: ".bacon-locations"
   Info  11:33:29 notify.info found file: "../"
   Info  11:33:29 notify.info found file: "../.bacon-locations"
   Info  11:33:29 notify.info found file: "../../"
```

This change seems to get rid of the endless loop. I tested this on nvim 0.10.0 and 0.9.0